### PR TITLE
Pytides and rhgc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
 env:
   matrix:
     - DOCKER_ORG=climateimpactlab
-      IMAGE_NAME=bolliger32-clawpack-image
+      IMAGE_NAME=clawpack-image
       SOURCE_IMAGE=rhodium/worker:v0.2.5
 
 notifications:
@@ -22,18 +22,18 @@ install:
 
 script:
   - docker run -t $DOCKER_ORG/$IMAGE_NAME:$TRAVIS_COMMIT /usr/bin/env bash /clawpack/run_tests.sh
+  - docker push "$DOCKER_ORG/$IMAGE_NAME:$TRAVIS_COMMIT"
 
 deploy:
   - provider: script
-    script: docker tag $DOCKER_ORG/$IMAGE_NAME:$TRAVIS_COMMIT $DOCKER_ORG/$IMAGE_NAME:$TRAVIS_BRANCH && docker push "$DOCKER_ORG/$IMAGE_NAME:$TRAVIS_COMMIT" && docker push "$DOCKER_ORG/$IMAGE_NAME:$TRAVIS_BRANCH"
+    script: docker tag $DOCKER_ORG/$IMAGE_NAME:$TRAVIS_COMMIT $DOCKER_ORG/$IMAGE_NAME:$TRAVIS_BRANCH && docker push "$DOCKER_ORG/$IMAGE_NAME:$TRAVIS_BRANCH"
     skip_cleanup: true
     on:
       all_branches: true
       condition: $TRAVIS_BRANCH != master
-      tags: false
 
   - provider: script
-    script: docker tag $DOCKER_ORG/$IMAGE_NAME:$TRAVIS_COMMIT $DOCKER_ORG/$IMAGE_NAME:latest && docker push "$DOCKER_ORG/$IMAGE_NAME:$TRAVIS_COMMIT" && docker push "$DOCKER_ORG/$IMAGE_NAME:latest"
+    script: docker tag $DOCKER_ORG/$IMAGE_NAME:$TRAVIS_COMMIT $DOCKER_ORG/$IMAGE_NAME:latest && docker push "$DOCKER_ORG/$IMAGE_NAME:latest"
     skip_cleanup: true
     on:
       branch: master

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ WORKDIR /clawpack
 ## more current version
 RUN source activate worker && \
   pip install -e . && \
-  pip install matplotlib yolk3k pytides rhg_compute_tools>=0.1.6 -- no-cache-dir
+  pip install matplotlib yolk3k pytides rhg_compute_tools>=0.1.6 --no-cache-dir
 
 WORKDIR /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,11 @@ SHELL ["/bin/bash", "-c"]
 
 WORKDIR /clawpack
 
+## currently pinning rhg_compute_tools until latest worker image version has
+## more current version
 RUN source activate worker && \
   pip install -e . && \
-  pip install matplotlib && \
-  pip install yolk3k
+  pip install matplotlib yolk3k pytides rhg_compute_tools>=0.1.6 -- no-cache-dir
 
 WORKDIR /
 


### PR DESCRIPTION
- add pytides and rhg-compute to this image
- clean up some of the .travis file
- change to clawpack-image instead of bolliger32-clawpack-image